### PR TITLE
Something that worked on the ec2 instance when run by hand

### DIFF
--- a/ansible.cfg
+++ b/ansible.cfg
@@ -1,0 +1,14 @@
+[defaults]
+remote_user = installer
+roles_path = roles
+;inventory = inventory/$(hostname -s)/hosts.ini # Use -i <inventory instead>
+interpreter_python = auto_silent
+pipelining = True
+callback_enabled = profile_tasks
+
+[privilege_escalation]
+become_method=sudo
+become_user=root
+
+#[diff]
+#always = yes

--- a/bootstrap.yaml
+++ b/bootstrap.yaml
@@ -1,0 +1,6 @@
+- name: Hello world
+  hosts: localhost
+  tasks:
+  - name: Debug something
+    ansible.builtin.debug:
+      msg: Hello world.

--- a/collections/requirements.yaml
+++ b/collections/requirements.yaml
@@ -1,0 +1,5 @@
+---
+collections:
+- name: https://github.com/k3s-io/k3s-ansible.git
+  type: git
+  version: 1.0.1

--- a/local_inventory.yaml
+++ b/local_inventory.yaml
@@ -1,0 +1,5 @@
+hosts:
+  localhost:
+    vars:
+      ansible_connection: local
+      ansible_python_interpreter: "{{ ansible_playbook_python }}"

--- a/local_inventory.yaml
+++ b/local_inventory.yaml
@@ -5,3 +5,43 @@ k3s_cluster:
         localhost:
           ansible_connection: local
           ansible_python_interpreter: "{{ ansible_playbook_python }}"
+  # Required Vars
+  vars:
+    k3s_version: v1.33.2+k3s1
+    # The token should be a random string of reasonable length. You can generate
+    # one with the following commands:
+    # - openssl rand -base64 64
+    # - pwgen -s 64 1
+    # You can use ansible-vault to encrypt this value / keep it secret.
+    # Or you can omit it if not using Vagrant and let the first server automatically generate one.
+    token: "changeme!"
+    api_endpoint: "{{ hostvars[groups['server'][0]]['ansible_host'] | default(groups['server'][0]) }}"
+
+    # Optional vars
+    # extra_server_args: ""
+    # extra_agent_args: ""
+    # cluster_context: k3s-ansible
+    # api_port: 6443
+    # k3s_server_location: /var/lib/rancher/k3s
+    # systemd_dir: /etc/systemd/system
+    # extra_service_envs: [ 'ENV_VAR1=VALUE1', 'ENV_VAR2=VALUE2' ]
+    # user_kubectl: true, by default kubectl is symlinked and configured for use by ansible_user. Set to false to only kubectl via root user.
+
+    # Manifests or Airgap should be either full paths or relative to the playbook directory.
+    # List of locally available manifests to apply to the cluster, useful for PVCs or Traefik modifications.
+    # extra_manifests: [ '/path/to/manifest1.yaml', '/path/to/manifest2.yaml' ]
+    # airgap_dir: /tmp/k3s-airgap-images
+
+    # server_config_yaml:  |
+    #   This is now an inner yaml file. Maintain the indentation.
+    #   YAML here will be placed as the content of /etc/rancher/k3s/config.yaml
+    #   See https://docs.k3s.io/installation/configuration#configuration-file
+    # agent_config_yaml:  |
+    #   Same as server_config_yaml, but for the agent nodes.
+    #   YAML here will be placed as the content of /etc/rancher/k3s/config.yaml
+    #   See https://docs.k3s.io/installation/configuration#configuration-file
+    # registries_config_yaml:  |
+    #   Containerd can be configured to connect to private registries and use them to pull images as needed by the kubelet.
+    #   YAML here will be placed as the content of /etc/rancher/k3s/registries.yaml
+    #   See https://docs.k3s.io/installation/private-registry
+

--- a/local_inventory.yaml
+++ b/local_inventory.yaml
@@ -1,5 +1,7 @@
-hosts:
-  localhost:
-    vars:
-      ansible_connection: local
-      ansible_python_interpreter: "{{ ansible_playbook_python }}"
+k3s_cluster:
+  children:
+    server:
+      hosts:
+        localhost:
+          ansible_connection: local
+          ansible_python_interpreter: "{{ ansible_playbook_python }}"

--- a/site.yaml
+++ b/site.yaml
@@ -1,0 +1,30 @@
+- name: Clone and run
+  hosts: localhost
+  tasks:
+    - name: Clone k3s-ansible repo
+      git:
+        repo: https://github.com/k3s-io/k3s-ansible.git
+        dest: /opt/k3s
+        update: yes
+        
+    - name: Ensure inventory/sample directory exists
+      file:
+        path: /opt/k3s/inventory/sample
+        state: directory
+
+    - name: Create inventory file for k3s-ansible
+      copy:
+        dest: /opt/k3s/inventory/sample/hosts.ini
+        content: |
+          [local]
+          localhost ansible_connection=local ansible_python_interpreter=/usr/bin/python3
+
+    - name: Run k3s ansible playbook
+      ansible.builtin.command: ansible-playbook site.yml -i inventory/sample/hosts.ini
+      args:
+        chdir: /opt/k3s
+
+    - name: Clone vmboot or another repo
+      git:
+        repo: https://github.com/holmanb/vmboot.git
+        dest: /opt/vmboot

--- a/site.yaml
+++ b/site.yaml
@@ -1,30 +1,23 @@
-- name: Clone and run
-  hosts: localhost
+- name: Our pre-setup
+  hosts: k3s_cluster
   tasks:
-    - name: Clone k3s-ansible repo
-      git:
-        repo: https://github.com/k3s-io/k3s-ansible.git
-        dest: /opt/k3s
-        update: yes
-        
-    - name: Ensure inventory/sample directory exists
-      file:
-        path: /opt/k3s/inventory/sample
-        state: directory
+  - name: Hello world
+    ansible.builtin.copy:
+      dest: /tmp/debug.txt
+      content: |
+        Environment Variables ("environment"):
+        --------------------------------
+        {{ environment | to_nice_json }}
 
-    - name: Create inventory file for k3s-ansible
-      copy:
-        dest: /opt/k3s/inventory/sample/hosts.ini
-        content: |
-          [local]
-          localhost ansible_connection=local ansible_python_interpreter=/usr/bin/python3
+        GROUP NAMES Variables ("group_names"):
+        --------------------------------
+        {{ group_names | to_nice_json }}
 
-    - name: Run k3s ansible playbook
-      ansible.builtin.command: ansible-playbook site.yml -i inventory/sample/hosts.ini
-      args:
-        chdir: /opt/k3s
+        GROUPS Variables ("groups"):
+        --------------------------------
+        {{ groups | to_nice_json }}
 
-    - name: Clone vmboot or another repo
-      git:
-        repo: https://github.com/holmanb/vmboot.git
-        dest: /opt/vmboot
+        HOST Variables ("hostvars"):
+        --------------------------------
+        {{ hostvars[inventory_hostname] | to_nice_json }}
+- ansible.builtin.import_playbook: k3s.orchestration.site


### PR DESCRIPTION
It lives!!
```
root@ip-w.x.y.z:~# kubectl get pods -A
NAMESPACE     NAME                                      READY   STATUS      RESTARTS        AGE
kube-system   coredns-5688667fd4-rtppr                  1/1     Running     0               4m32s
kube-system   helm-install-traefik-crd-k64jz            0/1     Completed   0               4m30s
kube-system   helm-install-traefik-p226k                0/1     Completed   2               4m30s
kube-system   local-path-provisioner-774c6665dc-nphnk   1/1     Running     0               4m32s
kube-system   metrics-server-6f4c6675d5-gkjck           1/1     Running     1 (2m46s ago)   4m32s
kube-system   svclb-traefik-e296442a-p6t2j              2/2     Running     0               3m40s
kube-system   traefik-c98fdf6fb-89hsl                   1/1     Running     1 (2m49s ago)   3m40s
```